### PR TITLE
quick item image glitch fix

### DIFF
--- a/Project/Fall2020_CSC403_Project/FrmLevel.cs
+++ b/Project/Fall2020_CSC403_Project/FrmLevel.cs
@@ -884,6 +884,8 @@ namespace Fall2020_CSC403_Project
                 this.Controls.Remove(Game.CurrentArea.Structures[i].Pic);
             }
 
+
+
             GC.Collect();
 
         }
@@ -903,8 +905,6 @@ namespace Fall2020_CSC403_Project
             Game.Areas = new Area[10];
 
             GC.Collect();
-
-
 
         }
 

--- a/Project/MyGameLibrary/Inventory.cs
+++ b/Project/MyGameLibrary/Inventory.cs
@@ -192,11 +192,12 @@ namespace MyGameLibrary
             {
                 return;
             }
+            Game.CurrentArea.Items.Add(item);
 
             Position new_position = new Position(Game.player.Position.x, Game.player.Position.y);
             new_position.x = Game.player.facing == Facing.Left ? new_position.x - item.Pic.Size.Width - 10 : new_position.x + item.Pic.Size.Width + 10;
+
             item.SetEntityPosition(new_position);
-            Game.CurrentArea.Items.Add(item);
         }
 
         public void DropAll(Position position)


### PR DESCRIPTION
items showed up if you drop them in an area and then die in that area if that area is not the original item area